### PR TITLE
Allow image files to be symbolic links

### DIFF
--- a/mythtv/libs/libmythmetadata/imagemanager.cpp
+++ b/mythtv/libs/libmythmetadata/imagemanager.cpp
@@ -285,7 +285,7 @@ ImageAdapterBase::ImageAdapterBase() :
     // Apply filters to only detect image files
     m_dirFilter.setNameFilters(glob);
     m_dirFilter.setFilter(QDir::AllDirs | QDir::Files | QDir::Readable |
-                          QDir::NoDotAndDotDot | QDir::NoSymLinks);
+                          QDir::NoDotAndDotDot);
 
     // Sync files before dirs to improve thumb generation response
     // Order by time (oldest first) - this determines the order thumbs appear


### PR DESCRIPTION
A valuable use case for me, personally, is to have my images organized stored based on how they were acquired, but then write scripts to organize them more systematically, with symlinks back to the source files.

The current code prevents that by ignoring symbolic links.  That choice has existed since commit f3ba1b37c4c6db470bf21dcb54f77cd949777f63 in 2013 which originated this function afaict.  It's not clear to me if ignoring symlinks solves a problem or was just chosen arbitrarily.  The videos viewer works fine with symlinks, so this makes the gallery more in step with video files.

This was entered in ticket 13626:
  https://code.mythtv.org/trac/ticket/13626